### PR TITLE
remove uuid dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "devDependencies": {
     "@types/events": "^3.0.0",
-    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
     "eslint": "^8.23.1",
@@ -24,7 +23,6 @@
   "dependencies": {
     "events": "^3.3.0",
     "immer": "^9.0.15",
-    "js-base64": "^3.7.5",
-    "uuid": "^9.0.0"
+    "js-base64": "^3.7.5"
   }
 }

--- a/src/builders/GenericItemBuilder.ts
+++ b/src/builders/GenericItemBuilder.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from "uuid";
 import PlayerApi from "../api/PlayerApi";
 import { AttachmentBehavior, Item, Layer } from "../types/items/Item";
 import { Metadata } from "../types/Metadata";
@@ -17,7 +16,7 @@ export abstract class GenericItemBuilder<B extends GenericItemBuilder<B>> {
   constructor(player: PlayerApi) {
     this._item = {
       createdUserId: player.id,
-      id: uuid(),
+      id: crypto.randomUUID(),
       name: "Item",
       zIndex: Date.now(),
       lastModified: new Date().toISOString(),

--- a/src/messages/MessageBus.ts
+++ b/src/messages/MessageBus.ts
@@ -1,6 +1,5 @@
 import { isMessage } from "./Message";
 import { EventEmitter } from "events";
-import { v4 as uuid } from "uuid";
 
 class MessageBus extends EventEmitter {
   ready: boolean = false;
@@ -71,7 +70,7 @@ class MessageBus extends EventEmitter {
     data: unknown,
     timeout = 5000,
   ): Promise<ReturnValue> => {
-    const nonce = `_${uuid()}`;
+    const nonce = `_${crypto.randomUUID()}`;
     this.send(id, data, nonce);
     return Promise.race([
       new Promise<ReturnValue>((resolve, reject) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,11 +72,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@typescript-eslint/eslint-plugin@^5.38.0":
   version "5.38.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.0.tgz#ac919a199548861012e8c1fb2ec4899ac2bc22ae"
@@ -884,11 +879,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
As recommended [here (Note 2)](https://github.com/uuidjs/uuid#readme) this dep is no longer doing useful work as it is provided by browsers via the [Web Crypto Api](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API).

[crypto.randomUUID()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID): creates uuid v4

[Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility)