### PR TITLE
remove js-base64 dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "events": "^3.3.0",
     "immer": "^9.0.15",
-    "js-base64": "^3.7.5",
     "uuid": "^9.0.0"
   }
 }

--- a/src/common/getDetails.ts
+++ b/src/common/getDetails.ts
@@ -1,12 +1,10 @@
-import { decode } from "js-base64";
-
 export function getDetails() {
   const urlSearchParams = new URLSearchParams(window.location.search);
   const ref = urlSearchParams.get("obrref");
   let origin = "";
   let roomId = "";
   if (ref) {
-    const decodedRef = decode(ref);
+    const decodedRef = atob(ref);
     const parts = decodedRef.split(" ");
     if (parts.length === 2) {
       origin = parts[0];

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,11 +596,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-js-base64@^3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.5.tgz#21e24cf6b886f76d6f5f165bfcd69cc55b9e3fca"
-  integrity sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==
-
 js-sdsl@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.4.tgz#78793c90f80e8430b7d8dc94515b6c77d98a26a6"


### PR DESCRIPTION
Remove dependency that is functionally equivalent to a web api implemented by the browser.

[atob](https://developer.mozilla.org/en-US/docs/Web/API/atob)
> The atob() function decodes a string of data which has been encoded using [Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64) encoding.